### PR TITLE
Added a suggested change to the DNSKEYMissingFromServers error flagging

### DIFF
--- a/dnsviz/analysis/offline.py
+++ b/dnsviz/analysis/offline.py
@@ -2167,7 +2167,10 @@ class OfflineDomainNameAnalysis(OnlineDomainNameAnalysis):
                 # if the key is shown to be signing anything other than the
                 # DNSKEY RRset, or if it associated with a DS or trust anchor,
                 # then mark it as an error; otherwise, mark it as a warning.
-                if dnskey in self.zsks or dnskey in self.dnskey_with_ds or dnskey.rdata in trusted_keys_rdata:
+
+                ##paras/shuque: suggested change to only warn if a KSK has a corresponding DS record in parent
+                ### Changes suggested related to Model2 of https://tools.ietf.org/html/draft-huque-dnsop-multi-provider-dnssec-03
+                if dnskey in self.zsks  or dnskey.rdata in trusted_keys_rdata:
                     dnskey.errors.append(err)
                 else:
                     dnskey.warnings.append(err)


### PR DESCRIPTION
Reference draft : https://tools.ietf.org/html/draft-huque-dnsop-multi-provider-dnssec-03

Multi-provider Dnssec signing model 2, suggests that multiple DNS providers can independently sign a common DNS zone. They each will have a separate KSK/ZSK.

Example of the error flagged by DnsViz : http://dnsviz.net/d/multisign2.huque.com/W0pV5g/dnssec/

