### PR TITLE
WIP: travis CI: run online tests as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,6 @@ addons:
 install:
   - pip install -r requirements.txt
   - pip install .
-script: python tests/offline_tests.py
+script:
+  - python tests/offline_tests.py
+  - python tests/online_tests.py


### PR DESCRIPTION
Even though the online tests might be unstable due to network issue, I think it's worth to test the `probe` component as well.

The tests could be turned off if they prove to be too unstable...