### PR TITLE
Replace libnacl with py-cryptography, add support for algo 16 (Ed448)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:edge
 
 RUN apk add python3 graphviz ttf-liberation libsodium bind bind-tools
 RUN apk add --virtual builddeps linux-headers python3-dev graphviz-dev gcc libc-dev openssl-dev swig && \
-	pip3 install pygraphviz m2crypto dnspython libnacl && \
+	pip3 install pygraphviz m2crypto dnspython cryptography && \
 	apk del builddeps
 
 COPY . /tmp/dnsviz

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Instructions for running in a Docker container are also available
 
 * M2Crypto (0.28.0 or later) - https://gitlab.com/m2crypto/m2crypto
 
-* libnacl - https://github.com/saltstack/libnacl
+* Cryptography (2.6 or later) - https://cryptography.io/
 
 Note that the software versions listed above are known to work with the current
 version of DNSViz.  Other versions might also work well together, but might
@@ -85,7 +85,7 @@ $ source ~/myenv/bin/activate
 ```
 (Note that this installs the dependencies that are python packages, but some of
 these packages have non-python dependecies, such as Graphviz (required for
-pygraphviz) and libsodium (required for libnacl), that are not installed
+pygraphviz) and OpenSSL (required for Cryptography), that are not installed
 automatically.)
 
 Next download and install DNSViz from the Python Package Index (PyPI):
@@ -121,9 +121,9 @@ $ cp dist/dnsviz-*.tar.gz ~/rpmbuild/SOURCES/
 $ cp contrib/dnsviz-py${PY_VERS}.spec ~/rpmbuild/SPECS/dnsviz.spec
 ```
 
-Install dnspython, pygraphviz, M2Crypto, and libnacl.
+Install dnspython, pygraphviz, M2Crypto, and Cryptography.
 ```
-$ sudo dnf install python${PY_VERS}-dns python${PY_VERS}-pygraphviz python${PY_VERS}-libnacl
+$ sudo dnf install python${PY_VERS}-dns python${PY_VERS}-pygraphviz python${PY_VERS}-cryptography
 ```
 For python2:
 ```

--- a/contrib/dnsviz-py2.spec
+++ b/contrib/dnsviz-py2.spec
@@ -15,7 +15,7 @@ BuildRequires:  make
 Requires:       python2-pygraphviz >= 1.3
 Requires:       m2crypto >= 0.28.0
 Requires:       python2-dns >= 1.13
-Requires:       python2-libnacl
+Requires:       python2-cryptography
 
 %description
 DNSViz is a tool suite for analysis and visualization of Domain Name System

--- a/contrib/dnsviz-py3.spec
+++ b/contrib/dnsviz-py3.spec
@@ -15,7 +15,7 @@ BuildRequires:  make
 Requires:       python3-pygraphviz >= 1.3
 Requires:       python3-m2crypto >= 0.28.0
 Requires:       python3-dns >= 1.13
-Requires:       python3-libnacl
+Requires:       python3-cryptography
 
 %description
 DNSViz is a tool suite for analysis and visualization of Domain Name System

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 dnspython
 pygraphviz
 m2crypto
-libnacl
+cryptography

--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,7 @@ powers the Web-based analysis available at http://dnsviz.net/ .''',
                 'pygraphviz (>=1.1)',
                 'm2crypto (>=0.24.0)',
                 'dnspython (>=1.11)',
-                'libnacl',
+                'cryptography (>=2.6)',
         ],
         classifiers=[
                 'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
This replaces the current libnacl-based code for handling algo 15 (Ed25519) with code using [python-cryptography](https://cryptography.io/), and adds support for algo 16 (Ed448), hence fixing feature request #28.