### PR TITLE
pool.terminate() instead of pool.close() (fix #46)

### DIFF
--- a/dnsviz/commands/probe.py
+++ b/dnsviz/commands/probe.py
@@ -304,7 +304,9 @@ class ParallelAnalystMixin(object):
             pool.terminate()
             raise
 
-        pool.close()
+        # pool.close() will hang here
+        # in some cases
+        pool.terminate()
         pool.join()
         return name_objs
 


### PR DESCRIPTION
`pool.close()` hangs in some cases when using the probe command with
multiple threads. `pool.terminate()` seems to have less of that issue.

If you run the commands @tomaskrizek posted, it hangs a little near the end, but that's because of the [`result.get()`](https://github.com/dnsviz/dnsviz/blob/master/dnsviz/commands/probe.py#L302) line. It seems like most of the pool's results get saved up until the end and then they all return at once. If you put a print statement right above that line, you'll see what I mean.
