### PR TITLE
Fix it so that responses without the DO bit set do accept the aa=0

### DIFF
--- a/dnsviz/analysis/offline.py
+++ b/dnsviz/analysis/offline.py
@@ -1322,9 +1322,9 @@ class OfflineDomainNameAnalysis(OnlineDomainNameAnalysis):
                         if response.is_referral(query.qname, query.rdtype, query.rdclass, qname_obj.name):
                             ds_referral = True
 
-                    if ds_referral:
+                    if ds_referral and response.is_dnssec_response():
                         Errors.DomainNameAnalysisError.insert_into_list(Errors.ReferralForDSQuery(parent=fmt.humanize_name(qname_obj.name)), group, server, client, response)
-                    else:
+                    elif not ds_referral:
                         Errors.DomainNameAnalysisError.insert_into_list(Errors.NotAuthoritative(), group, server, client, response)
 
             elif qname_obj.analysis_type == ANALYSIS_TYPE_RECURSIVE:

--- a/dnsviz/response.py
+++ b/dnsviz/response.py
@@ -493,6 +493,11 @@ class DNSResponse:
 
         return self.message is not None and bool(self.message.flags & dns.flags.AA)
 
+    def is_dnssec_response(self):
+        '''Return True if the message has the DNSSEC OK (DO) bit set.'''
+
+        return self.message is not None and not bool(self.message.ednsflags & dns.flags.DO)
+
     def is_referral(self, qname, rdtype, rdclass, bailiwick, proper=False):
         '''Return True if this response yields a referral for the queried
         name.'''


### PR DESCRIPTION
Since DS records are only considered special when supporting DNSSEC, having aa=0 on a delegation point for a DS qtype is actually valid if you set DO=0.

This fixes the incorrect errors displayed for example for www.netflix.com: https://dnsviz.net/d/www.netflix.com/XtAhDw/dnssec/