### PR TITLE
fix comparing record TTL and RRSIG expiration time

### DIFF
--- a/dnsviz/analysis/status.py
+++ b/dnsviz/analysis/status.py
@@ -279,7 +279,7 @@ class RRSIGStatus(object):
             if self.validation_status == RRSIG_STATUS_VALID:
                 self.validation_status = RRSIG_STATUS_EXPIRED
             self.errors.append(Errors.ExpirationInPast(expiration=fmt.timestamp_to_datetime(self.rrsig.expiration), reference_time=fmt.timestamp_to_datetime(self.reference_ts)))
-        elif self.reference_ts + min_ttl >= self.rrsig.expiration:
+        elif self.reference_ts + min_ttl > self.rrsig.expiration:
             self.errors.append(Errors.TTLBeyondExpiration(expiration=fmt.timestamp_to_datetime(self.rrsig.expiration), rrsig_ttl=min_ttl, reference_time=fmt.timestamp_to_datetime(self.reference_ts)))
         elif self.reference_ts + CLOCK_SKEW_WARNING >= self.rrsig.expiration:
             self.warnings.append(Errors.ExpirationWithinClockSkew(expiration=fmt.timestamp_to_datetime(self.rrsig.expiration), reference_time=fmt.timestamp_to_datetime(self.reference_ts)))


### PR DESCRIPTION
DNSViz reports an error if the record TTL matches the expiration time exactly:

> With a TTL of 86400 the RRSIG RR can be in the cache of a non-validating resolver until 0 second after it expires at 2021-07-09 14:07:36+00:00.

This PR should fix that.

I also wonder if that check is valid. [RFC 4035 Section 5.3.3](https://datatracker.ietf.org/doc/html/rfc4035#section-5.3.3) states that the TTL of the record in the cache should be reduced if the signature would expire before the TTL drops down to zero:

```
   If the resolver accepts the RRset as authentic, the validator MUST
   set the TTL of the RRSIG RR and each RR in the authenticated RRset to
   a value no greater than the minimum of:

   o  the RRset's TTL as received in the response;

   o  the RRSIG RR's TTL as received in the response;

   o  the value in the RRSIG RR's Original TTL field; and

   o  the difference of the RRSIG RR's Signature Expiration time and the
      current time.
```