### PR TITLE
Skip tests when resolv.conf is not available

### DIFF
--- a/dnsviz/commands/probe.py
+++ b/dnsviz/commands/probe.py
@@ -1273,7 +1273,7 @@ class ArgHelper:
             try:
                 resolver = Resolver.from_file(RESOLV_CONF, StandardRecursiveQueryCD, transport_manager=tm)
             except ResolvConfError:
-                raise argparse.ArgumentTypeError('If servers are not specified with the %s option, then %s must have valid nameserver entries.\n' % \
+                raise ResolvConfError('If servers are not specified with the %s option, then %s must have valid nameserver entries.\n' % \
                         (self._arg_mapping['recursive_servers'], RESOLV_CONF))
             if (WILDCARD_EXPLICIT_DELEGATION, dns.rdatatype.NS) not in self.explicit_delegations:
                 self.explicit_delegations[(WILDCARD_EXPLICIT_DELEGATION, dns.rdatatype.NS)] = dns.rrset.RRset(WILDCARD_EXPLICIT_DELEGATION, dns.rdataclass.IN, dns.rdatatype.NS)
@@ -1511,6 +1511,11 @@ def main(argv):
             arghelper.serve_zones()
         except argparse.ArgumentTypeError as e:
             arghelper.parser.error(str(e))
+        except ResolvConfError as e:
+            arghelper.parser.print_usage(sys.stderr)
+            sys.stderr.write("%(prog)s: error: %(errmsg)s\n" % {
+                             'prog': arghelper.parser.prog, 'errmsg': str(e) })
+            sys.exit(5)
         except (ZoneFileServiceError, MissingExecutablesError) as e:
             s = str(e)
             if s:

--- a/dnsviz/config.py.in
+++ b/dnsviz/config.py.in
@@ -32,7 +32,7 @@ if (hasattr(sys, 'real_prefix') or hasattr(sys, 'base_prefix')) and \
     DNSVIZ_INSTALL_PREFIX = sys.prefix
 else:
     DNSVIZ_INSTALL_PREFIX = _prefix
-DNSVIZ_SHARE_PATH = os.path.join(DNSVIZ_INSTALL_PREFIX, 'share', 'dnsviz')
+DNSVIZ_SHARE_PATH = os.getenv('DNSVIZ_SHARE_PATH', os.path.join(DNSVIZ_INSTALL_PREFIX, 'share', 'dnsviz'))
 JQUERY_PATH = __JQUERY_PATH__
 JQUERY_UI_PATH = __JQUERY_UI_PATH__
 JQUERY_UI_CSS_PATH = __JQUERY_UI_CSS_PATH__

--- a/doc/man/dnsviz-probe.1
+++ b/doc/man/dnsviz-probe.1
@@ -326,6 +326,8 @@ The network was unavailable for diagnostic queries.
 There was an error processing the input or saving the output.
 .IP 4
 Program execution was interrupted, or an unknown error occurred.
+.IP 5
+No recursive resolvers found in resolv.conf nor given on command line.
 .SH SEE ALSO
 .BR dnsviz(1),
 .BR dnsviz-grok(1),

--- a/tests/test_dnsviz_probe_run_offline.py
+++ b/tests/test_dnsviz_probe_run_offline.py
@@ -41,19 +41,27 @@ class DNSProbeRunOfflineTestCase(unittest.TestCase):
         os.remove(self.output.name)
         subprocess.check_call(['rm', '-rf', self.run_cwd])
 
+    def assertReturnCode(self, retcode):
+        if retcode == 5:
+            self.skipTest("No resolvers available")
+        else:
+            self.assertEqual(retcode, 0)
+
+
     def test_dnsviz_probe_input(self):
         with io.open(self.output.name, 'wb') as fh_out:
             with gzip.open(EXAMPLE_AUTHORITATIVE) as fh_in:
                 p = subprocess.Popen(['dnsviz', 'probe', '-d', '0', '-r', '-', 'example.com'], stdin=subprocess.PIPE, stdout=fh_out)
                 p.communicate(fh_in.read())
-                self.assertEqual(p.returncode, 0)
+                self.assertReturnCode(p.returncode)
 
         with io.open(self.output.name, 'wb') as fh:
             self.assertEqual(subprocess.call(['dnsviz', 'probe', '-d', '0', '-r', self.example_auth_out.name, 'example.com'], stdout=fh), 0)
 
     def test_dnsviz_probe_names_input(self):
         with io.open(self.output.name, 'wb') as fh:
-            self.assertEqual(subprocess.call(['dnsviz', 'probe', '-d', '0', '-r', self.example_auth_out.name, '-f', self.names_file.name], stdout=fh), 0)
+            ret = subprocess.call(['dnsviz', 'probe', '-d', '0', '-r', self.example_auth_out.name, '-f', self.names_file.name], stdout=fh)
+            self.assertReturnCode(ret)
 
         with io.open(self.output.name, 'wb') as fh_out:
             with io.open(self.names_file.name, 'rb') as fh_in:
@@ -63,7 +71,8 @@ class DNSProbeRunOfflineTestCase(unittest.TestCase):
 
     def test_dnsviz_probe_output(self):
         with io.open(self.output.name, 'wb') as fh:
-            self.assertEqual(subprocess.call(['dnsviz', 'probe', '-d', '0', '-r', self.example_auth_out.name, 'example.com'], cwd=self.run_cwd, stdout=fh), 0)
+            ret = subprocess.call(['dnsviz', 'probe', '-d', '0', '-r', self.example_auth_out.name, 'example.com'], cwd=self.run_cwd, stdout=fh)
+            self.assertReturnCode(ret)
 
         with io.open(self.output.name, 'wb') as fh:
             self.assertEqual(subprocess.call(['dnsviz', 'probe', '-d', '0', '-r', self.example_auth_out.name, '-o', '-', 'example.com'], cwd=self.run_cwd, stdout=fh), 0)
@@ -77,35 +86,35 @@ class DNSProbeRunOfflineTestCase(unittest.TestCase):
             with gzip.open(EXAMPLE_AUTHORITATIVE) as fh_in:
                 p = subprocess.Popen(['dnsviz', 'probe', '-d', '0', '-r', '-', 'example.com'], stdin=subprocess.PIPE, stdout=fh_out)
                 p.communicate(fh_in.read())
-                self.assertEqual(p.returncode, 0)
+                self.assertReturnCode(p.returncode)
 
         with io.open(self.output.name, 'wb') as fh_out:
             with gzip.open(ROOT_AUTHORITATIVE) as fh_in:
                 p = subprocess.Popen(['dnsviz', 'probe', '-d', '0', '-r', '-', '.'], stdin=subprocess.PIPE, stdout=fh_out)
                 p.communicate(fh_in.read())
-                self.assertEqual(p.returncode, 0)
+                self.assertReturnCode(p.returncode)
 
     def test_dnsviz_probe_rec(self):
         with io.open(self.output.name, 'wb') as fh_out:
             with gzip.open(EXAMPLE_RECURSIVE) as fh_in:
                 p = subprocess.Popen(['dnsviz', 'probe', '-d', '0', '-r', '-', 'example.com'], stdin=subprocess.PIPE, stdout=fh_out)
                 p.communicate(fh_in.read())
-                self.assertEqual(p.returncode, 0)
+                self.assertReturnCode(p.returncode)
 
         with io.open(self.output.name, 'wb') as fh_out:
             with gzip.open(ROOT_RECURSIVE) as fh_in:
                 p = subprocess.Popen(['dnsviz', 'probe', '-d', '0', '-r', '-', '.'], stdin=subprocess.PIPE, stdout=fh_out)
                 p.communicate(fh_in.read())
-                self.assertEqual(p.returncode, 0)
+                self.assertReturnCode(p.returncode)
 
     def test_dnsviz_probe_auth_local(self):
         with io.open(self.output.name, 'wb') as fh:
-            self.assertEqual(subprocess.call(
+            self.assertReturnCode(subprocess.call(
                 ['dnsviz', 'probe', '-d', '0', '-A',
                     '-x' 'example.com:%s' % EXAMPLE_COM_SIGNED,
                     '-N' 'example.com:%s' % EXAMPLE_COM_DELEGATION,
                     '-D' 'example.com:%s' % EXAMPLE_COM_DELEGATION,
-                    'example.com'], stdout=fh), 0)
+                    'example.com'], stdout=fh))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_dnsviz_probe_run_online.py
+++ b/tests/test_dnsviz_probe_run_online.py
@@ -14,24 +14,29 @@ class DNSVizProbeRunOnlineTestCase(unittest.TestCase):
     def tearDown(self):
         os.remove(self.output.name)
 
+    def assertReturnCode(self, retcode):
+        if retcode == 5:
+            self.skipTest("No recursive resolves found nor given")
+        else:
+            self.assertEqual(retcode, 0)
+
     def test_dnsviz_probe_auth(self):
         with io.open(self.output.name, 'wb') as fh:
-            self.assertEqual(subprocess.call(['dnsviz', 'probe', '-d', '0', '-A', '.'], stdout=fh), 0)
+            self.assertReturnCode(subprocess.call(['dnsviz', 'probe', '-d', '0', '-A', '.'], stdout=fh))
 
         with io.open(self.output.name, 'wb') as fh:
-            self.assertEqual(subprocess.call(['dnsviz', 'probe', '-d', '0', '-A', 'example.com'], stdout=fh), 0)
+            self.assertReturnCode(subprocess.call(['dnsviz', 'probe', '-d', '0', '-A', 'example.com'], stdout=fh))
 
     def test_dnsviz_probe_rec(self):
         with io.open(self.output.name, 'wb') as fh:
-            self.assertEqual(subprocess.call(['dnsviz', 'probe', '-d', '0', '.'], stdout=fh), 0)
+            self.assertReturnCode(subprocess.call(['dnsviz', 'probe', '-d', '0', '.'], stdout=fh))
 
         with io.open(self.output.name, 'wb') as fh:
-            self.assertEqual(subprocess.call(['dnsviz', 'probe', '-d', '0', 'example.com'], stdout=fh), 0)
+            self.assertReturnCode(subprocess.call(['dnsviz', 'probe', '-d', '0', 'example.com'], stdout=fh))
 
     def test_dnsviz_probe_rec_multi(self):
         with io.open(self.output.name, 'wb') as fh:
-            self.assertEqual(subprocess.call(['dnsviz', 'probe', '-d', '0', '-t', '3', '.', 'example.com', 'example.net'], stdout=fh), 0)
-
+            self.assertReturnCode(subprocess.call(['dnsviz', 'probe', '-d', '0', '-t', '3', '.', 'example.com', 'example.net'], stdout=fh))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Another changes to work with pytest better. Return special exit code 5 when resolvers are not available. Check it and skip some tests instead of failing them. Would help in restricted environment builds.

Allow also DNSVIZ_SHARE_PATH override from environment. Needed for testing build, when not yet installed by root into final destination.
