### PR TITLE
Fix NSID decoding error

### DIFF
--- a/dnsviz/response.py
+++ b/dnsviz/response.py
@@ -228,9 +228,9 @@ class DNSResponse:
             # dnspython < 2.6 with Generic Option
             data = nsid_opt.data
 
-        try:
+        if all(c >= 0x20 and c <= 0x7e for c in data):
             nsid_val = data.decode('ascii')
-        except UnicodeDecodeError:
+        else:
             nsid_val = '0x' + lb2s(binascii.hexlify(data))
 
         return nsid_val

--- a/dnsviz/response.py
+++ b/dnsviz/response.py
@@ -221,10 +221,18 @@ class DNSResponse:
         except IndexError:
             return None
 
+        if hasattr(dns.edns, 'NSIDOption'):
+            # dnspython >= 2.6 with NSIDOption
+            data = nsid_opt.nsid
+        else:
+            # dnspython < 2.6 with Generic Option
+            data = nsid_opt.data
+
         try:
-            nsid_val = nsid_opt.data.decode('ascii')
+            nsid_val = data.decode('ascii')
         except UnicodeDecodeError:
-            nsid_val = '0x' + lb2s(binascii.hexlify(nsid_opt.data))
+            nsid_val = '0x' + lb2s(binascii.hexlify(data))
+
         return nsid_val
 
     def request_cookie_tag(self):

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+import binascii
+import dns.message
+import unittest
+
+from dnsviz.response import DNSResponse
+
+class DNSResponseTestCase(unittest.TestCase):
+    def test_nsid_val(self):
+        tests = [
+            # DNS message in wire format, expected NSID value
+            ("26898105000100000000000106646e7376697a036e657400001c000100002904d00000000000120003000e68756d616e2d7265616461626c65", "human-readable"),
+            ("43468105000100000000000106646e7376697a036e657400001c000100002904d000000000000800030004c01dcafe", "0xc01dcafe"),
+        ]
+        for wire, nsid_val in tests:
+            msg = dns.message.from_wire(binascii.unhexlify(wire))
+            resp = DNSResponse(msg, 0, None, None, None, None, None, None, None, False)
+            self.assertEqual(resp.nsid_val(), nsid_val)


### PR DESCRIPTION
I'm submitting a patch which fixes NSID parsing in the current version of DNSViz and dnspython.

Current error:

```
% ./bin/dnsviz grok -r /tmp/probe.json
Traceback (most recent call last):
  File "/home/jan/devel/dnsviz/./bin/dnsviz", line 141, in <module>
    main()
  File "/home/jan/devel/dnsviz/./bin/dnsviz", line 138, in main
    mod.main(args)
  File "/home/jan/devel/dnsviz/dnsviz/commands/grok.py", line 491, in main
    name_obj.serialize_status(d, loglevel=arghelper.log_level)
  File "/home/jan/devel/dnsviz/dnsviz/analysis/offline.py", line 3310, in serialize_status
    query_serialized = self._serialize_query_status(self.queries[(qname, rdtype)], consolidate_clients=consolidate_clients, loglevel=loglevel, html_format=html_format)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jan/devel/dnsviz/dnsviz/analysis/offline.py", line 3067, in _serialize_query_status
    rrset_serialized = self._serialize_rrset_info(rrset_info, consolidate_clients=consolidate_clients, loglevel=loglevel, html_format=html_format)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jan/devel/dnsviz/dnsviz/analysis/offline.py", line 2874, in _serialize_rrset_info
    rrsig_serialized = rrsig_status.serialize(consolidate_clients=consolidate_clients, loglevel=loglevel, html_format=html_format, map_ip_to_ns_name=self.zone.get_ns_name_for_ip)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jan/devel/dnsviz/dnsviz/analysis/status.py", line 385, in serialize
    nsid = response.nsid_val()
           ^^^^^^^^^^^^^^^^^^^
  File "/home/jan/devel/dnsviz/dnsviz/response.py", line 225, in nsid_val
    nsid_val = nsid_opt.data.decode('ascii')
               ^^^^^^^^^^^^^
AttributeError: 'NSIDOption' object has no attribute 'data'
```